### PR TITLE
union type aliases, proper fixed type support

### DIFF
--- a/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -29,7 +29,7 @@ object ModuleGenerator {
         case Schema.Type.BYTES => PrimitiveType.Bytes
         case Schema.Type.DOUBLE => PrimitiveType.Double
         case Schema.Type.ENUM => types.getOrElse(schema.getFullName, enumFor(schema))
-        case Schema.Type.FIXED => PrimitiveType.String
+        case Schema.Type.FIXED => types.getOrElse(schema.getFullName, fixedFor(schema))
         case Schema.Type.FLOAT => PrimitiveType.Float
         case Schema.Type.INT => PrimitiveType.Int
         case Schema.Type.LONG => PrimitiveType.Long
@@ -46,6 +46,12 @@ object ModuleGenerator {
       val enum = EnumType(schema.getNamespace, schema.getName, schema.getEnumSymbols.asScala.toList)
       types.put(schema.getFullName, enum)
       enum
+    }
+
+    def fixedFor(schema: Schema): FixedType = {
+      val fixed = FixedType(schema.getNamespace, schema.getName, schema.getFixedSize)
+      types.put(schema.getFullName, fixed)
+      fixed
     }
 
     def recordFor(schema: Schema): RecordType = {
@@ -77,6 +83,8 @@ case class RecordType(namespace: String, name: String, fields: Seq[FieldDef]) ex
 case class EnumType(namespace: String, name: String, symbols: Seq[String]) extends Module
 
 case class MapType(valueType: Type) extends Type
+
+case class FixedType(namespace: String, name: String, length: Int) extends Module
 
 case class PrimitiveType(baseType: String) extends Type
 
@@ -128,6 +136,7 @@ object TypeRenderer {
       case RecordType(namespace, name, _) => namespace + "." + name
       case EnumType(namespace, name, _) => namespace + "." + name
       case MapType(valueType) => s"Map[String, ${renderType(valueType)}]"
+      case FixedType(namespace, name, _) => namespace + "." + name
       case UnionType(Seq()) => "shapeless.CNil"
       case UnionType(Seq(NullType, right)) => s"Option[${renderType(right)}]"
       case UnionType(Seq(left, right)) if !forceCoproduct => s"Either[${renderType(left)}, ${renderType(right)}]"

--- a/src/main/scala/com/sksamuel/avro4s/ModuleRenderer.scala
+++ b/src/main/scala/com/sksamuel/avro4s/ModuleRenderer.scala
@@ -3,10 +3,36 @@ package com.sksamuel.avro4s
 class ModuleRenderer {
 
   def apply(record: RecordType): String = {
-    s"//auto generated code by avro4s\ncase class ${record.name}(\n" + record.fields.map(TypeRenderer.render).mkString(",\n") + "\n)"
+    val caseClass = s"//auto generated code by avro4s\ncase class ${record.name}(\n" + record.fields.map(TypeRenderer.render).mkString(",\n") + "\n)"
+
+    val unionFieldTypes = record.fields.collect {
+      case FieldDef(name, unionType@UnionType(types)) if types.count(_ != NullType) > 2 =>
+        s"  type ${name.capitalize}Type = ${TypeRenderer.renderType(unionType)}"
+    }
+
+    if (unionFieldTypes.nonEmpty) {
+      val companionObject = s"//auto generated code by avro4s\nobject ${record.name} {\n" +
+        unionFieldTypes.mkString("\n") +
+        "\n}"
+      caseClass ++ "\n\n" ++ companionObject
+    } else {
+      caseClass
+    }
+  }
+
+  def apply(fixed: FixedType): String = {
+    s"//auto generated code by avro4s\n@com.sksamuel.avro4s.AvroFixed(${fixed.length})\ncase class ${fixed.name}(bytes: scala.collection.mutable.WrappedArray.ofByte) extends AnyVal"
   }
 
   def apply(enum: EnumType): String = {
     s"//auto generated code by avro4s\npublic enum ${enum.name}" + enum.symbols.mkString("{\n    ", ", ", "\n}")
+  }
+
+  def apply(module: Module): String = {
+    module match {
+      case r: RecordType => apply(r)
+      case e: EnumType => apply(e)
+      case f: FixedType => apply(f)
+    }
   }
 }

--- a/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
+++ b/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
@@ -20,8 +20,9 @@ object TemplateGenerator {
     }
 
     // records can be grouped into a single file per package
-    val records = modules.collect {
+    val recordsAndFixedTypes = modules.collect {
       case record: RecordType => record
+      case fixed: FixedType => fixed
     }.groupBy(_.namespace).map { case (namespace, records) =>
       val defin = s"package $namespace\n\n" + records.map(renderer.apply).mkString("\n\n")
       Template(
@@ -31,6 +32,6 @@ object TemplateGenerator {
       )
     }
 
-    enums ++ records
+    enums ++ recordsAndFixedTypes
   }
 }


### PR DESCRIPTION
For union types, added `type ${typeName}Type = x :+: y :+: ... :+: CNil` into companion object.

Added proper support for `fixed` types, currently represented as:
`@AvroFixed(32) case class SHA256(bytes: WrappedArray.ofByte) extends AnyVal`