### PR TITLE
Support schemas referencing schemas in different files

### DIFF
--- a/src/main/scala/com/sksamuel/avro4s/Avro4sSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/avro4s/Avro4sSbtPlugin.scala
@@ -49,10 +49,13 @@ object Avro4sSbtPlugin extends AutoPlugin {
       (resourceDirectory in avro2Class).value,
       (resourceManaged in avroIdl2Avro).value
     ),
+    resources in avro2Class := (resourceDirectories in avro2Class).value.flatMap(getRecursiveListOfFiles),
+
     sourceManaged in avro2Class := (sourceManaged in Compile).value / avroDirectoryName.value,
 
     resourceDirectory in avroIdl2Avro := (resourceDirectory in Compile).value / avroDirectoryName.value,
     resourceManaged in avroIdl2Avro := (resourceManaged in Compile).value / avroDirectoryName.value,
+    resources in avroIdl2Avro := getRecursiveListOfFiles((resourceDirectory in avroIdl2Avro).value),
 
     managedSourceDirectories in Compile <+= sourceManaged in avro2Class,
     managedResourceDirectories in Compile <+= resourceManaged in avroIdl2Avro,
@@ -75,7 +78,7 @@ object Avro4sSbtPlugin extends AutoPlugin {
     streams.value.log.info("--------------------------------------------------------------")
 
     val combinedFileFilter = inc -- exc
-    val allFiles = inDir.flatMap(getRecursiveListOfFiles)
+    val allFiles = (resources in avro2Class).value
     val schemaFiles = Option(allFiles.filter(combinedFileFilter.accept))
     streams.value.log.info(s"[sbt-avro4s] Found ${schemaFiles.fold(0)(_.length)} schemas")
     schemaFiles.map { f =>
@@ -102,7 +105,7 @@ object Avro4sSbtPlugin extends AutoPlugin {
     streams.value.log.info("--------------------------------------------------------------")
 
     val combinedFileFilter = inc -- exc
-    val allFiles = getRecursiveListOfFiles(inDir)
+    val allFiles = (resources in avroIdl2Avro).value
     val idlFiles = Option(allFiles.filter(combinedFileFilter.accept))
     streams.value.log.info(s"[sbt-avro4s] Found ${idlFiles.fold(0)(_.length)} IDLs")
 

--- a/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -14,7 +14,10 @@ object ModuleGenerator {
 
   def apply(in: InputStream): Seq[Module] = ModuleGenerator(Seq(new Parser().parse(in)))
   def apply(file: File): Seq[Module] = ModuleGenerator.fromFiles(Seq(file))
-  def fromFiles(files: Seq[File]): Seq[Module] = ModuleGenerator(files.map(f => new Parser().parse(f)))
+  def fromFiles(files: Seq[File]): Seq[Module] = ModuleGenerator {
+    val parser = new Parser()
+    files.map(parser.parse)
+  }
 
   def apply(schemata: Seq[Schema]): Seq[Module] = {
 


### PR DESCRIPTION
This requires that the schemas are parsed in such an order that the referred schemas are parsed first. To allow customization of the order the internal list of schema files is now exposed via the `resources` key.