### PR TITLE
Time logicalTypes

### DIFF
--- a/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -33,7 +33,11 @@ object ModuleGenerator {
         case Schema.Type.ENUM => types.getOrElse(schema.getFullName, enumFor(schema))
         case Schema.Type.FIXED => types.getOrElse(schema.getFullName, fixedFor(schema))
         case Schema.Type.FLOAT => PrimitiveType.Float
+        case Schema.Type.INT if schema.getProp("logicalType") == "time-millis" => PrimitiveType.Time
         case Schema.Type.INT => PrimitiveType.Int
+        case Schema.Type.LONG if schema.getProp("logicalType") == "time-micros"=> PrimitiveType.Time
+        case Schema.Type.LONG if schema.getProp("logicalType") == "timestamp-millis"=> PrimitiveType.Instant
+        case Schema.Type.LONG if schema.getProp("logicalType") == "timestamp-micros"=> PrimitiveType.Instant
         case Schema.Type.LONG => PrimitiveType.Long
         case Schema.Type.MAP => MapType(schemaToType(schema.getValueType))
         case Schema.Type.NULL => NullType
@@ -100,6 +104,8 @@ object PrimitiveType {
   val Long = PrimitiveType("Long")
   val String = PrimitiveType("String")
   val Int = PrimitiveType("Int")
+  val Instant = PrimitiveType("java.time.Instant")
+  val Time = PrimitiveType("java.time.LocalTime")
   val Boolean = PrimitiveType("Boolean")
 }
 

--- a/src/test/resources/gameofthrones.avsc
+++ b/src/test/resources/gameofthrones.avsc
@@ -31,6 +31,13 @@
       "type": "boolean"
     },
     {
+      "name": "airedDate",
+      "type": {
+        "type":"long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
       "name": "locations",
       "type": {
         "type": "array",

--- a/src/test/scala/com/sksamuel/avro4s/ClassRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ClassRendererTest.scala
@@ -16,6 +16,9 @@ class ClassRendererTest extends WordSpec with Matchers {
     "generate field for Boolean fields" in {
       fields should contain(FieldDef("aired", PrimitiveType("Boolean")))
     }
+    "generate field for Instant fields" in {
+      fields should contain(FieldDef("airedDate", PrimitiveType("java.time.Instant")))
+    }
     "generate field for Double fields" in {
       fields should contain(FieldDef("temperature", PrimitiveType("Double")))
     }

--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -57,9 +57,10 @@ class ModuleRendererTest extends WordSpec with Matchers {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[Either[Int, Boolean]]\n)"
     }
     "generate coproducts for union types of 3+ non-null types" in {
-      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)"
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n}"
     }
     "generate Option[coproducts] for union types of 3+ non-null types with null" in {
-      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)"
+      val actual = new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean)))))
+      actual shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n}"
     }}
 }

--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -5,6 +5,9 @@ import org.scalatest.{Matchers, WordSpec}
 class ModuleRendererTest extends WordSpec with Matchers {
 
   "new ModuleRenderer()" should {
+    "write field for Time" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Time)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: java.time.LocalTime\n)"
+    }
     "write field for Int" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.String)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: String\n)"
     }
@@ -16,6 +19,9 @@ class ModuleRendererTest extends WordSpec with Matchers {
     }
     "write field for doubles" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Double)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: Double\n)"
+    }
+    "write field for Instant" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Instant)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: java.time.Instant\n)"
     }
     "write field for longs" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Long)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: Long\n)"


### PR DESCRIPTION

Adds handling for time and timestamp logical types …The avro 1.8 specification defines multiple date related logical types and specifies how they should be mapped :  

 * [time-millis](https://avro.apache.org/docs/1.8.2/spec.html#Time+%28millisecond+precision%29) 
 * [time-micros](https://avro.apache.org/docs/1.8.2/spec.html#Time+%28microsecond+precision%29) 
 * [timestamp-millis](https://avro.apache.org/docs/1.8.2/spec.html#Timestamp+%28millisecond+precision%29) 
 * [timestamp-micros](https://avro.apache.org/docs/1.8.2/spec.html#Timestamp+%28microsecond+precision%29)

This PR adds the following mappings : 

 * (int, time-millis) => java.time.LocalTime 
 * (long, time-micros) => java.time.LocalTime 
 * (long, timestamp-millis) => java.time.Instant
 * (long, timestamp-micros => java.time.Instant 

Possible further inprovements to this feature :
 - Make the mapped types configurable.
 - Add mappings for date and duration types. 
 - Propose a more general mecanism to extends type and logicalType mapping to handle custom user types (iso8601 dates come to mind for example)


--

I tried to fix the tests,  I managed to do so for the unit tests but I am unsure how to fix the scripted sbt tests. They fail in the same way with and without my modification ...
