### PR TITLE
Fix 3+ coproduct tests

### DIFF
--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -57,9 +57,9 @@ class ModuleRendererTest extends WordSpec with Matchers {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[Either[Int, Boolean]]\n)"
     }
     "generate coproducts for union types of 3+ non-null types" in {
-      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)"
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)")
     }
     "generate Option[coproducts] for union types of 3+ non-null types with null" in {
-      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)"
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)")
     }}
 }


### PR DESCRIPTION
Saw your comment in https://github.com/sksamuel/sbt-avro4s/pull/9, seems it broke because https://github.com/sksamuel/sbt-avro4s/pull/9/files generates a companion object for the coproduct alias which made the equality. I "fixed" the test by relaxing the constraint. cc @ilya-epifanov