### PR TITLE
Cross build for SBT 0.13.X

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ val AvroVersion = "1.8.0"
 val ScalatestVersion = "3.0.0"
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.12.4",
   organization := "com.sksamuel.avro4s",
   scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8"),
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
@@ -36,6 +35,8 @@ lazy val root = (project in file(".")).
       "-Dplugin.version=" + version.value
     )},
     scriptedBufferLog := false,
+
+    crossSbtVersions := Vector("0.13.16", "1.0.4"),
 
     resolvers := ("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2") +: resolvers.value,
 

--- a/src/sbt-test/avro2Class/custom/test
+++ b/src/sbt-test/avro2Class/custom/test
@@ -1,2 +1,2 @@
 > avro2Class
-$ exists target/scala-2.10/src_managed/main/schemas/com/sksamuel/avro4s/json/domain/scala
+$ exists target/scala-2.10/src_managed/main/schemas/com/sksamuel/avro4s/json/domain.scala

--- a/src/sbt-test/avro2Class/managedSources/test
+++ b/src/sbt-test/avro2Class/managedSources/test
@@ -1,2 +1,2 @@
 > compile:managedSources
-$ exists target/scala-2.10/src_managed/main/avro/com/sksamuel/avro4s/json/domain/scala
+$ exists target/scala-2.10/src_managed/main/avro/com/sksamuel/avro4s/json/domain.scala

--- a/src/sbt-test/avro2Class/simple/test
+++ b/src/sbt-test/avro2Class/simple/test
@@ -1,2 +1,2 @@
 > avro2Class
-$ exists target/scala-2.10/src_managed/main/avro/com/sksamuel/avro4s/json/domain/scala
+$ exists target/scala-2.10/src_managed/main/avro/com/sksamuel/avro4s/json/domain.scala


### PR DESCRIPTION
@sksamuel This should enable cross-building for older versions of SBT.

You will need to change your `publish` command to `^publish`

You can also test it by prepending `^` to any other command like `^test` or `^scripted`

I added the scripted changes because it wasn't working on my machine(OS X 10.12), and it looked like a bug. I can change those back if they are supposed to be like that.

Let me know if you need anything changed here.