### PR TITLE
Timetypes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.pgp.PgpKeys
 import sbt._
 import sbt.Keys._
 
-val AvroVersion = "1.8.0"
+val AvroVersion = "1.8.2"
 val ScalatestVersion = "3.0.0"
 
 lazy val commonSettings = Seq(

--- a/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -35,7 +35,11 @@ object ModuleGenerator {
         case Schema.Type.ENUM => types.getOrElse(schema.getFullName, enumFor(schema))
         case Schema.Type.FIXED => types.getOrElse(schema.getFullName, fixedFor(schema))
         case Schema.Type.FLOAT => PrimitiveType.Float
+        case Schema.Type.INT if schema.getProp("logicalType") == "time-millis" => PrimitiveType.Time
         case Schema.Type.INT => PrimitiveType.Int
+        case Schema.Type.LONG if schema.getProp("logicalType") == "time-micros"=> PrimitiveType.Time
+        case Schema.Type.LONG if schema.getProp("logicalType") == "timestamp-millis"=> PrimitiveType.Instant
+        case Schema.Type.LONG if schema.getProp("logicalType") == "timestamp-micros"=> PrimitiveType.Instant
         case Schema.Type.LONG => PrimitiveType.Long
         case Schema.Type.MAP => MapType(schemaToType(schema.getValueType))
         case Schema.Type.NULL => NullType
@@ -108,6 +112,8 @@ object PrimitiveType {
   val Long = PrimitiveType("Long")
   val String = PrimitiveType("String")
   val Int = PrimitiveType("Int")
+  val Instant = PrimitiveType("java.time.Instant")
+  val Time = PrimitiveType("java.time.LocalTime")
   val Boolean = PrimitiveType("Boolean")
 }
 

--- a/src/sbt-test/avro2Class/idl/src/main/resources/avro/Order.avdl
+++ b/src/sbt-test/avro2Class/idl/src/main/resources/avro/Order.avdl
@@ -5,6 +5,6 @@ protocol Shop {
 
     record Order {
         array<com.sksamuel.avro4s.json.Product> product;
-        long occurredOn;
+        timestamp_ms occurredOn;
     }
 }

--- a/src/test/resources/gameofthrones.avsc
+++ b/src/test/resources/gameofthrones.avsc
@@ -31,6 +31,13 @@
       "type": "boolean"
     },
     {
+      "name": "airedDate",
+      "type": {
+        "type":"long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
       "name": "locations",
       "type": {
         "type": "array",

--- a/src/test/scala/com/sksamuel/avro4s/ClassRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ClassRendererTest.scala
@@ -16,6 +16,9 @@ class ClassRendererTest extends WordSpec with Matchers {
     "generate field for Boolean fields" in {
       fields should contain(FieldDef("aired", PrimitiveType("Boolean")))
     }
+    "generate field for Instant fields" in {
+      fields should contain(FieldDef("airedDate", PrimitiveType("java.time.Instant")))
+    }
     "generate field for Double fields" in {
       fields should contain(FieldDef("temperature", PrimitiveType("Double")))
     }

--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -63,17 +63,9 @@ class ModuleRendererTest extends WordSpec with Matchers {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[Either[Int, Boolean]]\n)"
     }
     "generate coproducts for union types of 3+ non-null types" in {
-//<<<<<<< HEAD
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)")
     }
     "generate Option[coproducts] for union types of 3+ non-null types with null" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)")
-//=======
-//      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n}"
-//    }
-//    "generate Option[coproducts] for union types of 3+ non-null types with null" in {
-//      val actual = new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean)))))
-//      actual shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n}"
-//>>>>>>> [Boyscout] fix failing test cases
     }}
 }

--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -5,6 +5,9 @@ import org.scalatest.{Matchers, WordSpec}
 class ModuleRendererTest extends WordSpec with Matchers {
 
   "new ModuleRenderer()" should {
+    "write field for Time" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Time)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: java.time.LocalTime\n)"
+    }
     "write field for Int" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.String)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: String\n)"
     }
@@ -16,6 +19,9 @@ class ModuleRendererTest extends WordSpec with Matchers {
     }
     "write field for doubles" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Double)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: Double\n)"
+    }
+    "write field for Instant" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Instant)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: java.time.Instant\n)"
     }
     "write field for longs" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("foo", PrimitiveType.Long)))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  foo: Long\n)"

--- a/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -57,9 +57,17 @@ class ModuleRendererTest extends WordSpec with Matchers {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[Either[Int, Boolean]]\n)"
     }
     "generate coproducts for union types of 3+ non-null types" in {
+//<<<<<<< HEAD
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)")
     }
     "generate Option[coproducts] for union types of 3+ non-null types with null" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) should include ("//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)")
+//=======
+//      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n}"
+//    }
+//    "generate Option[coproducts] for union types of 3+ non-null types with null" in {
+//      val actual = new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean)))))
+//      actual shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)\n\n//auto generated code by avro4s\nobject MyClass {\n  type NameType = Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n}"
+//>>>>>>> [Boyscout] fix failing test cases
     }}
 }


### PR DESCRIPTION
Based on the previous pull request by jeantil (https://github.com/sksamuel/sbt-avro4s/pull/18) adding support for logical time types.

This one fixes the merge conflict, and updates Avro to 1.8.2, which gives support for logical time type IDL names, eg timestamp_ms.