### PR TITLE
Make sbt-release publish this plugin for cross sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,22 @@ lazy val commonSettings = Seq(
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 )
 
+import ReleaseTransformations._
+lazy val releaseSteps = Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  releaseStepCommandAndRemaining("^ test"),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  releaseStepCommandAndRemaining("^ publishSigned"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
+
 lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
@@ -25,8 +41,8 @@ lazy val root = (project in file(".")).
     publishMavenStyle := true,
     SbtPgp.autoImport.useGpgAgent := true,
     SbtPgp.autoImport.useGpg := true,
-    sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-    sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := true,
+    sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := false,
+    sbtrelease.ReleasePlugin.autoImport.releaseProcess := releaseSteps,
     publishArtifact in Test := false,
     parallelExecution in Test := false,
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++ Seq(


### PR DESCRIPTION
sbt-release has no features for plugin cross releases so you have to manually specify the command for it. In our case, this means using the same commands with a `^` prepended.

This was based on https://github.com/sbt/sbt-release/blob/v1.0.6/build.sbt#L50 as referenced from https://github.com/sbt/sbt-release/issues/206

@sksamuel I apologize if I ended up wasting your time debugging this, I didn't think to look at how you were releasing the plugin.